### PR TITLE
Support for Marked 2

### DIFF
--- a/marked.py
+++ b/marked.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import subprocess
-import sublime
 import sublime_plugin
 
 
@@ -16,7 +15,15 @@ class MarkedCommand(sublime_plugin.WindowCommand):
         for k, v in proc_env.items():
             proc_env[k] = os.path.expandvars(v).encode(encoding)
 
-        subprocess.call(['open', '-a', 'Marked', filename], env=proc_env)
+        for app in ('Marked 2', 'Marked'):
+            try:
+                subprocess.check_call(
+                    ['open', '-a', app, filename],
+                    env=proc_env
+                )
+                break
+            except subprocess.CalledProcessError:
+                pass
 
     def is_enabled(self):
         return True


### PR DESCRIPTION
Tested with Marked 2 in place, wherein the file is opened in the Marked 2 application, and without, wherein the file is opened with the Marked application if it exists.
